### PR TITLE
updates for melodic (gazebo 9)

### DIFF
--- a/legged_controllers/include/legged_robot/quadruped_robot.h
+++ b/legged_controllers/include/legged_robot/quadruped_robot.h
@@ -3,6 +3,7 @@
 #include <utility/math_func.h>
 #include <array>
 #include <boost/scoped_ptr.hpp>
+#include <boost/shared_ptr.hpp>
 
 // ros
 #include <ros/console.h>


### PR DESCRIPTION
1. Added "#include <boost/shared_ptr.hpp>" in quadrupted_robot.h

2. Edited some codes so that the project can be built on ROS-Melodic.

3. Used  "#if GAZEBO_MAJOR_VERSION < 9" preprocessor macro so that
the codes can also be built on ROS-Kinetic.

4. "#if GAZEBO_MAJOR_VERSION < 9" should be removed when ROS-Melodic becomes the main development environments.
